### PR TITLE
Add support for new case semantic

### DIFF
--- a/c3voc_calendar.py
+++ b/c3voc_calendar.py
@@ -107,6 +107,7 @@ class C3VOCCalendar:
                         for case in source_event["cases"]:
                             if case in ["1", "2", "3", "4", "5", "6", "7", "8"]:
                                 room_cases.append("S" + case)
+                                audio_cases.append("A" + case)
                             elif case[0] == "A":
                                 audio_cases.append(case.upper())
                             else:


### PR DESCRIPTION
in the wiki writing `1, 2` is now equivalent to `S1, S2, A1, A2`